### PR TITLE
Add Register Endpoint

### DIFF
--- a/server/app/controllers/api/v1/auth_controller.rb
+++ b/server/app/controllers/api/v1/auth_controller.rb
@@ -1,0 +1,20 @@
+class Api::V1::AuthController < ApiController
+  def register
+    result = AuthenticationService.register(
+      email: user_params[:email],
+      password: user_params[:password]
+    )
+
+    if result.success?
+      render :json => { errors: [], resource: result.user }, :status => :created
+    else
+      render :json => { errors: result.user.errors.full_messages, resource: nil }, :status => :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :password).to_h.deep_symbolize_keys
+  end
+end

--- a/server/app/controllers/api_controller.rb
+++ b/server/app/controllers/api_controller.rb
@@ -1,0 +1,7 @@
+class ApiController < ApplicationController
+  rescue_from ActionController::ParameterMissing, with: :render_exception
+
+  def render_exception(exception)
+    render :json => {}, :status => :unprocessable_entity
+  end
+end

--- a/server/app/services/authentication_service.rb
+++ b/server/app/services/authentication_service.rb
@@ -1,0 +1,13 @@
+class AuthenticationService
+  def self.register(email:, password:)
+    user = User.new(email: email, password: password)
+
+    if user.save
+      user.auth_tokens.create!
+
+      OpenStruct.new(:user => user, :success? => true)
+    else
+      OpenStruct.new(:user => user, :success? => false)
+    end
+  end
+end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      post 'auth/register'
+    end
+  end
 end

--- a/server/spec/rails_helper.rb
+++ b/server/spec/rails_helper.rb
@@ -18,6 +18,9 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.include FactoryBot::Syntax::Methods
   config.infer_spec_type_from_file_location!
+  config.include JsonHelper, :type => :serializer
+  config.include JsonHelper, :type => :controller
+  config.include JsonHelper, :type => :request
   config.filter_rails_from_backtrace!
 end
 

--- a/server/spec/requests/auth_request_spec.rb
+++ b/server/spec/requests/auth_request_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "Authentication", type: :request do
+  describe "POST /register" do
+    let(:user_params) { attributes_for(:user) }
+
+    context "when given the required attributes" do
+      it "creates a user" do
+        expect do
+          post "/api/v1/auth/register", :params => { :user => user_params }
+
+          expect(response).to have_http_status(:created)
+        end.to change(User, :count).by(1)
+      end
+
+      it "creates an auth token" do
+        expect do
+          post "/api/v1/auth/register", :params => { :user => user_params }
+
+          expect(response).to have_http_status(:created)
+        end.to change(AuthToken, :count).by(1)
+      end
+
+      context "when they are invalid" do
+        it "returns http success" do
+          post "/api/v1/auth/register", :params => {
+            :user => {
+              :email => nil,
+              :password => nil,
+            }
+          }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context "when not given the required attributes" do
+      it "returns http success" do
+        post "/api/v1/auth/register"
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/server/spec/requests/auth_request_spec.rb
+++ b/server/spec/requests/auth_request_spec.rb
@@ -3,20 +3,14 @@ RSpec.describe "Authentication", type: :request do
     let(:user_params) { attributes_for(:user) }
 
     context "when given the required attributes" do
-      it "creates a user" do
+      it "creates a user and auth token" do
         expect do
           post "/api/v1/auth/register", :params => { :user => user_params }
 
           expect(response).to have_http_status(:created)
-        end.to change(User, :count).by(1)
-      end
-
-      it "creates an auth token" do
-        expect do
-          post "/api/v1/auth/register", :params => { :user => user_params }
-
-          expect(response).to have_http_status(:created)
-        end.to change(AuthToken, :count).by(1)
+          expect(json_body[:resource][:id]).not_to eq(nil)
+          expect(json_body[:resource][:email]).to eq(user_params[:email])
+        end.to change(User, :count).by(1).and change(AuthToken, :count).by(1)
       end
 
       context "when they are invalid" do

--- a/server/spec/support/json_helper.rb
+++ b/server/spec/support/json_helper.rb
@@ -1,0 +1,18 @@
+module JsonHelper
+  def json_body
+    if @last_response && @last_response == response
+      @json_body
+    else
+      @last_response = response
+      @json_body = JSON.parse(response.body)&.deep_symbolize_keys
+    end
+  end
+
+  def expected_json(object, serializer_klass, options = {})
+    expected_json_hash(object, serializer_klass, options).to_json
+  end
+
+  def expected_json_hash(object, serializer_klass, options = {})
+    serializer_klass.new(object).serializable_hash(options).deep_stringify_keys
+  end
+end


### PR DESCRIPTION
Add POST `/api/v1/auth/register` endpoint.


## Request

```
fetch('/api/v1/auth/register', {
  method: 'POST',
  body: JSON.stringify({
    user: {
      email: 'example@example.com',
      password: '12345678910',
    }
  }),
});
```

## Response

Valid Response
```json
{
  "errors": [],
  "resource": {
    "id": 1,
    "email": "example@example.com"
  }
}
```

With Errors 
```json
{
  "errors": ["Email can't be blank"],
  "resource": null
}
```

Fixes #5 