### PR TITLE
Add /api/v1/auth/me and /api/v1/auth/login routes

### DIFF
--- a/server/app/controllers/api/v1/auth_controller.rb
+++ b/server/app/controllers/api/v1/auth_controller.rb
@@ -1,16 +1,29 @@
 module Api
   module V1
     class AuthController < ApiController
+      skip_before_action :authenticate, only: %i[register login]
+
+      def me
+        render json: { errors: [], resource: current_user }, status: :ok
+      end
+
       def register
-        result = AuthenticationService.register(
-          email: user_params[:email],
-          password: user_params[:password]
-        )
+        result = AuthenticationService.register(email: user_params[:email], password: user_params[:password])
 
         if result.success?
           render json: { errors: [], resource: result.user }, status: :created
         else
           render json: { errors: result.user.errors.full_messages, resource: nil }, status: :unprocessable_entity
+        end
+      end
+
+      def login
+        result = AuthenticationService.login(email: user_params[:email], password: user_params[:password])
+
+        if result.success?
+          render json: { errors: [], resource: result.user, auth_token: result.user.auth_tokens.first.token }, status: :ok
+        else
+          render json: { errors: [I18n.t!("invalid_email_or_password")] }, status: :unprocessable_entity
         end
       end
 

--- a/server/app/controllers/api/v1/auth_controller.rb
+++ b/server/app/controllers/api/v1/auth_controller.rb
@@ -23,7 +23,7 @@ module Api
         if result.success?
           render json: { errors: [], resource: result.user, auth_token: result.user.auth_tokens.first.token }, status: :ok
         else
-          render json: { errors: [I18n.t!("invalid_email_or_password")] }, status: :unprocessable_entity
+          render json: { errors: [I18n.t!("invalid_email_or_password")], resource: nil, auth_token: nil }, status: :unprocessable_entity
         end
       end
 

--- a/server/app/controllers/api_controller.rb
+++ b/server/app/controllers/api_controller.rb
@@ -1,7 +1,29 @@
 class ApiController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  before_action :authenticate
+
   rescue_from ActionController::ParameterMissing, with: :render_exception
 
   def render_exception(_exception)
     render json: {}, status: :unprocessable_entity
+  end
+
+  def authenticate
+    authenticate_token || unauthorized
+  end
+
+  def authenticate_token
+    authenticate_with_http_token do |token, _options|
+      AuthToken.find_by(token: token)&.user
+    end
+  end
+
+  def current_user
+    @current_user ||= authenticate_token
+  end
+
+  def unauthorized
+    render json: {}, status: :unauthorized
   end
 end

--- a/server/app/services/authentication_service.rb
+++ b/server/app/services/authentication_service.rb
@@ -10,4 +10,14 @@ class AuthenticationService
       OpenStruct.new(user: user, success?: false)
     end
   end
+
+  def self.login(email:, password:)
+    user = User.find_by(email: email)
+
+    if user&.authenticate(password)
+      OpenStruct.new(success?: true, user: user)
+    else
+      OpenStruct.new(success?: false)
+    end
+  end
 end

--- a/server/config/locales/en.yml
+++ b/server/config/locales/en.yml
@@ -31,3 +31,4 @@
 
 en:
   hello: "Hello world"
+  invalid_email_or_password: "Invalid email or password provided."

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "auth/register"
+      post "auth/login"
+      get "auth/me"
     end
   end
 end

--- a/server/spec/factories/auth_tokens.rb
+++ b/server/spec/factories/auth_tokens.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :auth_token do
-    auth_token { SecureRandom.uuid }
+    token { SecureRandom.uuid }
     user
   end
 end

--- a/server/spec/rails_helper.rb
+++ b/server/spec/rails_helper.rb
@@ -21,6 +21,7 @@ RSpec.configure do |config|
   config.include JsonHelper, type: :serializer
   config.include JsonHelper, type: :controller
   config.include JsonHelper, type: :request
+  config.include AuthHelper, type: :controller
   config.filter_rails_from_backtrace!
 end
 

--- a/server/spec/requests/auth_request_spec.rb
+++ b/server/spec/requests/auth_request_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Authentication", type: :request do
-  describe "POST /register" do
+  describe "POST /api/v1/auth/register" do
     let(:user_params) { attributes_for(:user) }
 
     context "when given the required attributes" do
@@ -10,11 +10,12 @@ RSpec.describe "Authentication", type: :request do
           expect(response).to have_http_status(:created)
           expect(json_body[:resource][:id]).not_to eq(nil)
           expect(json_body[:resource][:email]).to eq(user_params[:email])
+          expect(json_body[:resource]).not_to include(:password)
         end.to change(User, :count).by(1).and change(AuthToken, :count).by(1)
       end
 
       context "when they are invalid" do
-        it "returns http success" do
+        it "returns unprocessable entity" do
           post "/api/v1/auth/register", params: {
             user: {
               email: nil,
@@ -23,15 +24,103 @@ RSpec.describe "Authentication", type: :request do
           }
 
           expect(response).to have_http_status(:unprocessable_entity)
+          expect(json_body[:errors]).to include("Password can't be blank")
+          expect(json_body[:errors]).to include("Email can't be blank")
         end
       end
     end
 
     context "when not given the required attributes" do
-      it "returns http success" do
+      it "returns unprocessable entity" do
         post "/api/v1/auth/register"
 
         expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_body).to be_empty
+      end
+    end
+  end
+
+  describe "POST /api/v1/auth/login" do
+    let(:password) { Faker::Internet.password }
+    let(:user) { create(:user, password: password) }
+    let!(:auth_token) { create(:auth_token, user: user) }
+    let(:user_params) do
+      {
+        email: user.email,
+        password: password
+      }
+    end
+
+    context "when given the required attributes" do
+      it "returns the auth token for the user" do
+        post "/api/v1/auth/login", params: { user: user_params }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_body[:auth_token]).to eq(auth_token.token)
+        expect(json_body[:resource][:id]).to eq(user.id)
+        expect(json_body[:resource][:email]).to eq(user.email)
+        expect(json_body[:resource]).not_to include(:password)
+        expect(json_body[:errors]).to be_empty
+      end
+
+      context "when they are invalid" do
+        it "returns unprocessable entity" do
+          post "/api/v1/auth/login", params: {
+            user: {
+              email: user.email,
+              password: nil
+            }
+          }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json_body[:auth_token]).to eq(nil)
+          expect(json_body[:resource]).to eq(nil)
+          expect(json_body[:errors]).to include(I18n.t!("invalid_email_or_password"))
+        end
+      end
+    end
+
+    context "when not given the required attributes" do
+      it "returns unprocessable entity" do
+        post "/api/v1/auth/login"
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_body).to be_empty
+      end
+    end
+  end
+
+  describe "GET /api/v1/auth/me" do
+    let(:user) { auth_token.user }
+    let!(:auth_token) { create(:auth_token) }
+
+    context "when the user has an API token" do
+      it "returns the user information" do
+        get "/api/v1/auth/me", headers: { "HTTP_AUTHORIZATION" => "Bearer #{auth_token.token}" }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_body[:resource][:id]).to eq(user.id)
+        expect(json_body[:resource][:email]).to eq(user.email)
+        expect(json_body[:resource]).not_to include(:password)
+        expect(json_body[:errors]).to be_empty
+      end
+
+      context "when the token is invalid" do
+        it "returns unprocessable entity" do
+          get "/api/v1/auth/me", headers: { "HTTP_AUTHORIZATION": "Bearer unknown" }
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(json_body).to be_empty
+        end
+      end
+    end
+
+    context "when not given the required attributes" do
+      it "returns unprocessable entity" do
+        get "/api/v1/auth/me", headers: { "HTTP_AUTHORIZATION": "Bearer unknown" }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(json_body).to be_empty
       end
     end
   end

--- a/server/spec/support/auth_helper.rb
+++ b/server/spec/support/auth_helper.rb
@@ -1,0 +1,15 @@
+module AuthHelper
+  NoTokenForUserError = Class.new(StandardError)
+
+  def login_user(user)
+    raise NoTokenForUserError if user.auth_tokens.size.zero?
+
+    login_with_token(user.auth_tokens.first.token)
+  end
+
+  def login_with_token(token)
+    return unless token
+
+    request.env["HTTP_AUTHORIZATION"] = "Bearer #{token}"
+  end
+end


### PR DESCRIPTION
Add POST `/api/v1/auth/login` endpoint and GET `/api/v1/auth/me` endpoint

Fixes #4 

# `/api/v1/auth/login`

## Request

```
fetch('/api/v1/auth/login', {
  method: 'POST',
  body: JSON.stringify({
    user: {
      email: 'example@example.com',
      password: '12345678910',
    }
  }),
});
```

## Response

Valid Response
```json
{
  "errors": [],
  "resource": {
    "id": 1,
    "email": "example@example.com"
  },
  "auth_token": "abc-1234"
}
```

With Errors 
```json
{
  "errors": ["Email can't be blank"],
  "resource": null,
  "auth_token": null
}
```

# `/api/v1/auth/me`

## Request

```
fetch('/api/v1/auth/login', {
  method: 'GET',
  headers: {
    HTTP_AUTHORIZATION: 'Bearer 1234-abc',
  },
});
```

## Response

Valid Response
```json
{
  "errors": [],
  "resource": {
    "id": 1,
    "email": "example@example.com"
  }
}
```

Invalid Token Response (Status 401)
```json
{}
```