### PR TITLE
Update the mui theme to use the secondary color and font from brand guide lines

### DIFF
--- a/web/src/pages/_document.js
+++ b/web/src/pages/_document.js
@@ -9,7 +9,7 @@ export default class Document extends NextDocument {
         <Head lang={'en'}>
           <meta content={'minimum-scale=1, initial-scale=1, width=device-width'} name={'viewport'} />
           <link
-            href={'https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap'}
+            href={'https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,400;0,800;1,400;1,800&display=swap'}
             rel={'stylesheet'}
           />
         </Head>

--- a/web/src/utils/theme.js
+++ b/web/src/utils/theme.js
@@ -1,5 +1,5 @@
 import { createMuiTheme } from '@material-ui/core/styles'
-import { deepOrange, pink } from '@material-ui/core/colors'
+import { pink } from '@material-ui/core/colors'
 
 // Create a theme instance.
 const theme = createMuiTheme({
@@ -8,7 +8,7 @@ const theme = createMuiTheme({
       main: '#4300FF',
     },
     secondary: {
-      main: deepOrange[500],
+      main: '#13efc3',
     },
     error: {
       main: pink.A400,
@@ -16,6 +16,9 @@ const theme = createMuiTheme({
     background: {
       default: '#fff',
     },
+  },
+  typography: {
+    fontFamily: 'Raleway',
   },
 })
 


### PR DESCRIPTION
Changes the font to use Raleway and the secondary color to teal based on the Can't Stop Columbus brand docs