### PR TITLE
Change up material imports

### DIFF
--- a/web/babel.config.js
+++ b/web/babel.config.js
@@ -2,6 +2,25 @@ module.exports = function (api) {
   api.cache.never()
   return {
     presets: ['next/babel'],
-    plugins: [],
+    plugins: [
+      [
+        'babel-plugin-import',
+        {
+          'libraryName': '@material-ui/core',
+          'libraryDirectory': '',
+          'camel2DashComponentName': false,
+        },
+        'core',
+      ],
+      [
+        'babel-plugin-import',
+        {
+          'libraryName': '@material-ui/icons',
+          'libraryDirectory': '',
+          'camel2DashComponentName': false,
+        },
+        'icons',
+      ],
+    ],
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "@testing-library/react-hooks": "^3.2.1",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^25.3.0",
+    "babel-plugin-import": "^1.13.0",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-react": "^7.18.0",

--- a/web/src/pages/_app.js
+++ b/web/src/pages/_app.js
@@ -1,7 +1,7 @@
-import CssBaseline from '@material-ui/core/CssBaseline'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import theme from 'src/utils/theme'
+import { CssBaseline } from '@material-ui/core'
 import { ThemeProvider } from '@material-ui/core/styles'
 
 export default function App({ Component, pageProps }) {

--- a/web/src/pages/login.js
+++ b/web/src/pages/login.js
@@ -1,16 +1,16 @@
-import Card from '@material-ui/core/Card'
-import CardActions from '@material-ui/core/CardActions'
-import CardContent from '@material-ui/core/CardContent'
-import Container from '@material-ui/core/Container'
 import FormErrors from '../utils/form-errors'
-import Grid from '@material-ui/core/Grid'
 import React, { useState } from 'react'
-import TextField from '@material-ui/core/TextField'
-import Typography from '@material-ui/core/Typography'
 import axios from 'axios'
-import { Button } from '@material-ui/core'
 import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Container,
   FormControl,
+  Grid,
+  TextField,
+  Typography,
 } from '@material-ui/core'
 import { Formik } from 'formik'
 import { makeStyles } from '@material-ui/core/styles'

--- a/web/src/pages/register.js
+++ b/web/src/pages/register.js
@@ -1,15 +1,17 @@
-import Card from '@material-ui/core/Card'
-import CardActions from '@material-ui/core/CardActions'
-import CardContent from '@material-ui/core/CardContent'
-import Container from '@material-ui/core/Container'
 import FormErrors from '../utils/form-errors'
-import Grid from '@material-ui/core/Grid'
 import React, { useState } from 'react'
-import TextField from '@material-ui/core/TextField'
-import Typography from '@material-ui/core/Typography'
 import axios from 'axios'
-import { Button } from '@material-ui/core'
-import { FormControl } from '@material-ui/core'
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Container,
+  FormControl,
+  Grid,
+  TextField,
+  Typography,
+} from '@material-ui/core'
 import { Formik } from 'formik'
 import { makeStyles } from '@material-ui/core/styles'
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -919,7 +919,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
@@ -1922,6 +1922,14 @@ babel-plugin-dynamic-import-node@^2.3.0:
   integrity sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
   dependencies:
     object.assign "^4.1.0"
+
+babel-plugin-import@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-import/-/babel-plugin-import-1.13.0.tgz#c532fd533df9db53b47d4d4db3676090fc5c07a5"
+  integrity sha512-bHU8m0SrY89ub2hBBuYjbennOeH0YUYkVpH6jxKFk0uD8rhN+0jNHIPtXnac+Vn7N/hgkLGGDcIoYK7je3Hhew==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/runtime" "^7.0.0"
 
 babel-plugin-istanbul@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
https://material-ui.com/guides/minimizing-bundle-size/

This page in the MaterialUI docs suggests adding `babel-plugin-import` to our babel configuration and using named imports for MUI components for optimal bundle size performance.