### PR TITLE
Fix Link components

### DIFF
--- a/web/src/pages/login.js
+++ b/web/src/pages/login.js
@@ -121,7 +121,9 @@ export default function Login() {
                     xs={12}
                   >
                     {'Need an account? '}
-                    <Link href={'/register'}>Sign Up</Link>
+                    <Link href={'/register'}>
+                      <a>Sign Up</a>
+                    </Link>
                   </Grid>
                 </Grid>
               </CardActions>

--- a/web/src/pages/register.js
+++ b/web/src/pages/register.js
@@ -136,7 +136,9 @@ export default function Register() {
                     xs={12}
                   >
                     {'Already have an account? '}
-                    <Link href={'/login'} >Log In</Link>
+                    <Link href={'/login'} >
+                      <a>Log In</a>
+                    </Link>
                   </Grid>
                 </Grid>
               </CardActions>


### PR DESCRIPTION
I noticed some warnings in the console about passing a string directly to `Link` rather than passing a string wrapper in an `<a>` tag. 

I tried changing the Nav drawer to use `Link`s but that messed up the styling and made it so you could only click the text so I decided to punt on it for now since they nav is functional as it is